### PR TITLE
新增趋势图分享预览与状态化链接

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -600,11 +600,22 @@ const elements = {
   trendsCanvas: document.getElementById("trendsChart"),
   trendsCaption: document.getElementById("trendsCaption"),
   trendsNote: document.getElementById("trendsNote"),
+  trendsShareButton: document.getElementById("trendsShareButton"),
+  shareDialog: document.getElementById("shareDialog"),
+  shareDialogTitle: document.getElementById("shareDialogTitle"),
+  shareDialogClose: document.getElementById("shareDialogClose"),
+  sharePreviewCanvas: document.getElementById("sharePreviewCanvas"),
+  shareCopyLinkButton: document.getElementById("shareCopyLinkButton"),
+  shareDownloadImageButton: document.getElementById("shareDownloadImageButton"),
+  shareStatus: document.getElementById("shareStatus"),
+  shareDialogCancel: document.getElementById("shareDialogCancel"),
 };
 
 let chartInstance = null;
 let trendsChartInstance = null;
 let isApplyingHashState = false;
+let shareImageCanvas = null;
+let shareRenderSerial = 0;
 
 initializeLocaleUi();
 initializeThemeUi();
@@ -796,6 +807,14 @@ function updateStaticCopy() {
   if (elements.modelPicker) {
     elements.modelPicker.setAttribute("aria-label", t("trends.picker.aria"));
   }
+  if (elements.trendsShareButton) {
+    elements.trendsShareButton.setAttribute("aria-label", t("trends.share.aria"));
+    elements.trendsShareButton.title = t("trends.share.aria");
+  }
+  updateShareDialogCopy();
+  if (elements.shareDialog && elements.shareDialog.open) {
+    refreshShareDialog();
+  }
   buildTrendsCategoryOptions();
   updateThemeToggle();
 }
@@ -898,6 +917,17 @@ function normalizeCountryFilter(value) {
   return VALID_COUNTRY_FILTERS.has(value) ? value : DEFAULT_COUNTRY_FILTER;
 }
 
+function normalizeTrendMode(value) {
+  return value === "percentile" ? "percentile" : "rank";
+}
+
+function parseTrendModels(value) {
+  return String(value || "")
+    .split("|")
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
 function parseHashState(rawHash = window.location.hash) {
   const hash = String(rawHash || "").replace(/^#/, "");
   const params = new URLSearchParams(hash);
@@ -906,6 +936,8 @@ function parseHashState(rawHash = window.location.hash) {
     hasParams: hash.length > 0,
     view: (params.get("view") || "").trim(),
     trendsCategory: (params.get("trendcat") || "").trim(),
+    trendsMode: normalizeTrendMode((params.get("trendmode") || "").trim()),
+    trendsModels: parseTrendModels(params.get("trendmodels")),
     category: (params.get("category") || "").trim(),
     datasetKey: (params.get("dataset") || "").trim(),
     inferenceFilter: normalizeInferenceFilter((params.get("inference") || "").trim()),
@@ -938,6 +970,11 @@ function buildHashFromState() {
     params.set("view", "trends");
     if (state.trends.category) {
       params.set("trendcat", state.trends.category);
+    }
+    params.set("trendmode", normalizeTrendMode(state.trends.mode));
+    const selectedModels = [...state.trends.selected].filter(Boolean);
+    if (selectedModels.length) {
+      params.set("trendmodels", selectedModels.join("|"));
     }
     return params.toString();
   }
@@ -994,6 +1031,8 @@ async function applyStateFromHash(rawHash = window.location.hash) {
         state.trends.loadedCategory = null;
       }
     }
+    state.trends.mode = hashState.trendsMode;
+    state.trends.selected = new Set(hashState.trendsModels);
     setView("trends", { sync: false });
     return true;
   }
@@ -1287,16 +1326,42 @@ function bindEventHandlers() {
       state.trends.category = category;
       state.trends.loadedCategory = null;
       state.trends.selected = new Set();
-      ensureTrendsData().then(renderTrends);
+      ensureTrendsData().then(() => {
+        renderTrends();
+        refreshShareDialog();
+      });
       syncHashFromState();
     });
   }
 
   if (elements.trendsModeSelect) {
     elements.trendsModeSelect.addEventListener("change", (event) => {
-      state.trends.mode = event.target.value === "rank" ? "rank" : "percentile";
+      state.trends.mode = normalizeTrendMode(event.target.value);
       renderTrendsChart();
       updateTrendsCaption();
+      syncHashFromState();
+      refreshShareDialog();
+    });
+  }
+
+  if (elements.trendsShareButton) {
+    elements.trendsShareButton.addEventListener("click", openShareDialog);
+  }
+  if (elements.shareDialogClose) {
+    elements.shareDialogClose.addEventListener("click", closeShareDialog);
+  }
+  if (elements.shareDialogCancel) {
+    elements.shareDialogCancel.addEventListener("click", closeShareDialog);
+  }
+  if (elements.shareCopyLinkButton) {
+    elements.shareCopyLinkButton.addEventListener("click", copyShareLink);
+  }
+  if (elements.shareDownloadImageButton) {
+    elements.shareDownloadImageButton.addEventListener("click", downloadShareImageAction);
+  }
+  if (elements.shareDialog) {
+    elements.shareDialog.addEventListener("click", (event) => {
+      if (event.target === elements.shareDialog) closeShareDialog();
     });
   }
 
@@ -2727,6 +2792,7 @@ async function ensureTrendsData() {
   state.trends.loadedCategory = category;
   state.trends.loading = false;
   buildTrendsModelList();
+  syncHashFromState();
 }
 
 function buildTrendsModelList() {
@@ -2763,6 +2829,9 @@ function renderTrends() {
   const hasData = state.trends.months.length > 0;
   if (elements.modelPicker) {
     elements.modelPicker.style.display = hasData ? "" : "none";
+  }
+  if (elements.trendsShareButton) {
+    elements.trendsShareButton.disabled = !hasData || !state.trends.selected.size;
   }
   const chartWrap = elements.trendsCanvas ? elements.trendsCanvas.parentElement : null;
   if (chartWrap) {
@@ -2820,6 +2889,8 @@ function renderModelPicker() {
       if (chartWrap) {
         chartWrap.style.display = state.trends.selected.size ? "" : "none";
       }
+      syncHashFromState();
+      refreshShareDialog();
     });
     picker.appendChild(chip);
   });
@@ -2966,6 +3037,183 @@ function renderTrendsChart() {
     },
     plugins: [trendEndLabelsPlugin],
   });
+}
+
+function buildTrendShareUrl() {
+  const url = new URL(window.location.href);
+  url.hash = buildHashFromState();
+  return url.toString();
+}
+
+function updateShareDialogCopy() {
+  if (!elements.shareDialog) return;
+  if (elements.shareDialogTitle) {
+    elements.shareDialogTitle.textContent = t("trends.share.title");
+  }
+  if (elements.shareDialogClose) {
+    elements.shareDialogClose.setAttribute("aria-label", t("trends.share.close"));
+  }
+  if (elements.shareCopyLinkButton) {
+    elements.shareCopyLinkButton.textContent = t("trends.share.copy");
+  }
+  if (elements.shareDownloadImageButton) {
+    elements.shareDownloadImageButton.textContent = t("trends.share.download");
+  }
+  if (elements.shareDialogCancel) {
+    elements.shareDialogCancel.textContent = t("trends.share.cancel");
+  }
+}
+
+function closeShareDialog() {
+  if (!elements.shareDialog) return;
+  if (typeof elements.shareDialog.close === "function" && elements.shareDialog.open) {
+    elements.shareDialog.close();
+  } else {
+    elements.shareDialog.removeAttribute("open");
+  }
+}
+
+async function openShareDialog() {
+  if (!elements.shareDialog) return;
+  if (!state.trends.selected.size) {
+    if (elements.shareStatus) elements.shareStatus.textContent = t("trends.share.empty");
+    return;
+  }
+  updateShareDialogCopy();
+  if (typeof elements.shareDialog.showModal === "function" && !elements.shareDialog.open) {
+    elements.shareDialog.showModal();
+  } else {
+    elements.shareDialog.setAttribute("open", "");
+  }
+  await refreshShareDialog();
+}
+
+async function copyTextToClipboard(text) {
+  if (!text) return false;
+  try {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (error) {
+    console.warn("Unable to write clipboard text:", error);
+  }
+
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = typeof document.execCommand === "function" && document.execCommand("copy");
+    textarea.remove();
+    return copied;
+  } catch (error) {
+    console.warn("Clipboard fallback failed:", error);
+    return false;
+  }
+}
+
+async function copyShareLink() {
+  const link = buildTrendShareUrl();
+
+  const copied = await copyTextToClipboard(link);
+  if (elements.shareStatus) {
+    elements.shareStatus.textContent = copied
+      ? t("trends.share.copied")
+      : t("trends.share.copyFailed");
+  }
+}
+
+function downloadShareImage() {
+  if (!shareImageCanvas) return false;
+  const link = document.createElement("a");
+  const category = state.trends.category || "trend";
+  link.download = "llm-benchmark-trend-" + category + ".png";
+  link.href = shareImageCanvas.toDataURL("image/png");
+  link.click();
+  return true;
+}
+
+function downloadShareImageAction() {
+  const downloaded = downloadShareImage();
+  if (elements.shareStatus) {
+    elements.shareStatus.textContent = downloaded ? t("trends.share.imageSaved") : t("trends.share.downloadFailed");
+  }
+}
+
+async function buildShareImage(url) {
+  if (!elements.trendsCanvas || !state.trends.selected.size) return null;
+  const canvas = document.createElement("canvas");
+  const width = 1800;
+  const height = 1120;
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d");
+  if (!context) return null;
+
+  const panelColor = getCssVariable("--color-panel", "#ffffff");
+  const textColor = getCssVariable("--color-text", "#212428");
+  const mutedColor = getCssVariable("--color-muted", "#77736c");
+  const borderColor = getCssVariable("--color-border", "#e3e1d9");
+  context.fillStyle = panelColor;
+  context.fillRect(0, 0, width, height);
+
+  context.fillStyle = textColor;
+  context.font = "600 42px system-ui, sans-serif";
+  context.fillText(t("app.title"), 88, 78);
+  context.fillStyle = mutedColor;
+  context.font = "24px system-ui, sans-serif";
+  context.fillText(t("header.subtitle").replace(/<[^>]+>/g, ""), 88, 120);
+
+  context.strokeStyle = borderColor;
+  context.lineWidth = 2;
+  context.beginPath();
+  context.moveTo(88, 154);
+  context.lineTo(width - 88, 154);
+  context.stroke();
+
+  const chartX = 72;
+  const chartY = 184;
+  const chartWidth = width - 144;
+  const chartHeight = 760;
+  context.drawImage(elements.trendsCanvas, chartX, chartY, chartWidth, chartHeight);
+
+  context.fillStyle = mutedColor;
+  context.font = "22px system-ui, sans-serif";
+  const categoryLabel = getCategoryLabel(state.trends.category);
+  const modeLabel = t("trends.mode." + normalizeTrendMode(state.trends.mode));
+  context.fillText(categoryLabel + " · " + modeLabel, 88, 1010);
+  context.fillText("llm_benchmark · trend share · " + new URL(url).host, 88, 1054);
+
+  return canvas;
+}
+
+async function refreshShareDialog() {
+  if (!elements.shareDialog) return;
+  const url = buildTrendShareUrl();
+
+  const serial = ++shareRenderSerial;
+  if (!state.trends.selected.size) {
+    shareImageCanvas = null;
+    if (elements.shareStatus) elements.shareStatus.textContent = t("trends.share.empty");
+    return;
+  }
+  await new Promise((resolve) => window.requestAnimationFrame(resolve));
+  const canvas = await buildShareImage(url);
+  if (serial !== shareRenderSerial) return;
+  shareImageCanvas = canvas;
+  if (!canvas || !elements.sharePreviewCanvas) return;
+  elements.sharePreviewCanvas.width = canvas.width;
+  elements.sharePreviewCanvas.height = canvas.height;
+  const previewContext = elements.sharePreviewCanvas.getContext("2d");
+  if (previewContext) {
+    previewContext.clearRect(0, 0, canvas.width, canvas.height);
+    previewContext.drawImage(canvas, 0, 0);
+  }
+  if (elements.shareStatus) elements.shareStatus.textContent = "";
 }
 
 function getCssVariable(name, fallback = "") {

--- a/docs/assets/i18n.js
+++ b/docs/assets/i18n.js
@@ -540,6 +540,53 @@ const TRANSLATIONS = {
     "zh-CN": "当月得分",
     "en-US": "Score",
   },
+
+  "trends.share.aria": {
+    "zh-CN": "分享当前趋势图",
+    "en-US": "Share current trend chart",
+  },
+  "trends.share.title": {
+    "zh-CN": "分享趋势图",
+    "en-US": "Share trend chart",
+  },
+
+  "trends.share.copy": {
+    "zh-CN": "复制链接",
+    "en-US": "Copy link",
+  },
+  "trends.share.copyFailed": {
+    "zh-CN": "复制失败，请检查浏览器权限。",
+    "en-US": "Copy failed. Check the browser permission.",
+  },
+  "trends.share.download": {
+    "zh-CN": "下载图片",
+    "en-US": "Download image",
+  },
+  "trends.share.close": {
+    "zh-CN": "关闭分享预览",
+    "en-US": "Close share preview",
+  },
+  "trends.share.cancel": {
+    "zh-CN": "取消",
+    "en-US": "Cancel",
+  },
+  "trends.share.copied": {
+    "zh-CN": "已复制链接",
+    "en-US": "Link copied",
+  },
+  "trends.share.downloadFailed": {
+    "zh-CN": "图片生成失败，请重试。",
+    "en-US": "The image could not be generated. Please try again.",
+  },
+  "trends.share.imageSaved": {
+    "zh-CN": "图片已下载",
+    "en-US": "Image downloaded",
+  },
+
+  "trends.share.empty": {
+    "zh-CN": "请至少选择一个模型后再分享。",
+    "en-US": "Select at least one model before sharing.",
+  },
   "codev3Note.title": {
     "zh-CN": "档位说明",
     "en-US": "Grade Guide",

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1577,3 +1577,230 @@ main {
     border-left: 0;
   }
 }
+/* ---------------- 趋势分享 ---------------- */
+
+.trends-toolbar-actions {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+.share-trigger {
+  appearance: none;
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition: color 0.16s ease, background-color 0.16s ease, transform 0.16s ease;
+}
+
+.share-trigger:hover:not(:disabled) {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.share-trigger:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.share-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.share-trigger-icon {
+  width: 27px;
+  height: 27px;
+}
+
+.share-trigger-icon path {
+  fill: var(--color-panel);
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 5.5;
+}
+
+.secondary-button,
+.primary-button {
+  appearance: none;
+  border-radius: var(--radius);
+  padding: 8px 14px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.secondary-button {
+  border: 1px solid var(--color-border);
+  background: var(--color-panel);
+  color: var(--color-muted);
+}
+
+.secondary-button:hover:not(:disabled) {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.primary-button {
+  border: 1px solid var(--color-accent);
+  background: var(--color-accent);
+  color: #ffffff;
+}
+
+.primary-button:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+.secondary-button:focus-visible,
+.primary-button:focus-visible,
+.share-dialog-close:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.secondary-button:disabled,
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.share-dialog {
+  width: min(720px, calc(100vw - 32px));
+  max-width: 720px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) + 4px);
+  background: var(--color-panel);
+  color: var(--color-text);
+  box-shadow: 0 24px 80px rgba(35, 32, 26, 0.22);
+}
+
+.share-dialog::backdrop {
+  background: rgba(30, 27, 23, 0.42);
+  backdrop-filter: blur(2px);
+}
+
+.share-dialog-shell {
+  display: flex;
+  flex-direction: column;
+  max-height: min(88vh, 860px);
+}
+
+.share-dialog-header {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 22px 24px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.share-dialog-header h2 {
+  margin: 0;
+  font-family: var(--font-family-serif);
+  font-size: 21px;
+  font-weight: 600;
+}
+
+.share-dialog-close {
+  appearance: none;
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding: 2px 7px;
+  border: 0;
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 25px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.share-dialog-close:hover {
+  color: var(--color-text);
+}
+
+.share-dialog-body {
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 24px 20px;
+}
+
+.share-preview-frame {
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-bg);
+}
+
+.share-preview-frame canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: min(52vh, 520px);
+  object-fit: contain;
+}
+
+.share-dialog-footer {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 24px 20px;
+  border-top: 1px solid var(--color-border);
+}
+
+.share-dialog-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.share-status {
+  min-height: 1.4em;
+  color: var(--color-muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 768px) {
+  .trends-toolbar-actions {
+    width: 100%;
+    justify-content: flex-end;
+    margin-left: 0;
+  }
+
+  .share-dialog-header,
+  .share-dialog-body,
+  .share-dialog-footer {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .share-dialog-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .share-dialog-actions {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .share-dialog-actions .secondary-button,
+  .share-dialog-actions .primary-button {
+    flex: 1;
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     />
 
     <link rel="icon" type="image/png" sizes="64x64" href="assets/favicon.png" />
-    <link rel="stylesheet" href="assets/styles.css?v=20260818-mobile-density" />
+    <link rel="stylesheet" href="assets/styles.css?v=20260820-trend-share-v4" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -163,6 +163,13 @@
             <label for="trendsModeSelect" id="trendsModeLabel"></label>
             <select id="trendsModeSelect" aria-label=""></select>
           </div>
+          <div class="trends-toolbar-actions">
+            <button id="trendsShareButton" type="button" class="share-trigger" aria-label="" title="">
+              <svg class="share-trigger-icon" viewBox="0 0 128 128" aria-hidden="true" focusable="false">
+                <path d="M27 108C30 80 46 60 70 53V32C70 27 76 25 80 29L115 60C120 64 120 70 115 74L80 104C76 108 70 105 70 100V83C51 89 38 99 29 114C26 118 23 114 24 110Z" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="chip-picker" id="modelPicker" role="group" aria-label=""></div>
         <div class="trends-chart-container">
@@ -171,11 +178,32 @@
         <p class="chart-caption" id="trendsCaption"></p>
         <p class="trends-note" id="trendsNote"></p>
       </section>
+      <dialog id="shareDialog" class="share-dialog" aria-labelledby="shareDialogTitle">
+        <div class="share-dialog-shell">
+          <div class="share-dialog-header">
+            <h2 id="shareDialogTitle"></h2>
+            <button id="shareDialogClose" type="button" class="share-dialog-close" aria-label="">×</button>
+          </div>
+          <div class="share-dialog-body">
+            <div class="share-preview-frame">
+              <canvas id="sharePreviewCanvas" class="share-preview-canvas"></canvas>
+            </div>
+          </div>
+          <div class="share-dialog-footer">
+            <span id="shareStatus" class="share-status" role="status"></span>
+            <div class="share-dialog-actions">
+              <button id="shareDialogCancel" type="button" class="secondary-button"></button>
+              <button id="shareCopyLinkButton" type="button" class="secondary-button"></button>
+              <button id="shareDownloadImageButton" type="button" class="primary-button"></button>
+            </div>
+          </div>
+        </div>
+      </dialog>
     </main>
     <footer class="page-footer">
       <small>Vibe Coding by Codex -> Kimi K3</small>
     </footer>
 
-    <script src="assets/app.js?v=20260818-seo" type="module"></script>
+    <script src="assets/app.js?v=20260820-trend-share-v4" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
为趋势页增加统一的分享入口。点击分享，可以预览当前趋势图，并选择下载图片或复制链接。图片分享包含项目名称、趋势图和项目水印；链接分享会保存数据类别、排名方式和已选模型，打开后可以恢复当前状态。

<img width="1101" height="909" alt="image" src="https://github.com/user-attachments/assets/abacb7b8-7c6f-438d-95a0-a8447fbd2478" />

希望解决的问题:目前分享链接无法保持模型的筛选状态